### PR TITLE
Fixed x86 test

### DIFF
--- a/pyasmjit/tests/pyasmjit_x86_test.py
+++ b/pyasmjit/tests/pyasmjit_x86_test.py
@@ -25,6 +25,6 @@ context_in = {
 print code
 print context_in
 
-rv, context_out = pyasmjit.execute(code, context_in)
+rv, context_out = pyasmjit.x86_execute(code, context_in)
 
 print context_out


### PR DESCRIPTION
Bug in pyasmjit_86_test; called execute rather than x86_execute. Also added an
__init__.py file for the tests directory (with the intention of fleshing these
out into unit tests in the future).