### PR TITLE
Fix interpretation of ARM-THUMB branches

### DIFF
--- a/barf/arch/arm/armbase.py
+++ b/barf/arch/arm/armbase.py
@@ -298,7 +298,7 @@ class ArmArchitectureInformation(ArchitectureInformation):
 
     def instr_is_branch(self, instruction):
         branch_instr = [
-            "b", "bx", "bne", "beq", "bpl", "ble", "bcs", "bhs", "blt", "bge",
+            "b", "bal", "bx", "bne", "beq", "bpl", "ble", "bcs", "bhs", "blt", "bge",
             "bhi", "blo", "bls"
         ]
 


### PR DESCRIPTION
Hi,

Right now the Arm backend class doesn't recognize certain unconditional branches as branches at all, due to some extra condition code information being added. Observe the following program:

    #!/usr/bin/python

    from capstone import *

    from barf.arch import ARCH_ARM_MODE_THUMB
    from barf.arch.arm.armdisassembler import ArmDisassembler
    from barf.arch.arm.armbase import ArmArchitectureInformation as Base

    code = b'\x45\xe7'

    md = Cs(CS_ARCH_ARM, CS_MODE_THUMB)
    capstone_insn = list(md.disasm(code, 0x0))[0]
    print(capstone_insn.mnemonic)

    base = Base(ARCH_ARM_MODE_THUMB)
    disasm = ArmDisassembler(architecture_mode=ARCH_ARM_MODE_THUMB)
    arm_insn = disasm.disassemble(code, 0)

    print(arm_insn)
    print(base.instr_is_branch(arm_insn))

Output (for me):

    b
    bal #-0x172
    False

Capstone correctly identifies the mnemonic of the given Thumb code as 'b' for branch. However, barf prints the mnemonic as 'bal', and the ArmArchitectureInformation class does not classify it as a branch instruction. (Obviously, this causes problems elsewhere).

The problem stems from the instr_is_branch method of ArmArchitectureInformation, which has a list of valid branch mnemonics. It has 'b', but the the 'mnemonic_full' property annotates the instruction with an extra 'al' condition code (for 'branch always' I guess). 'bal' is not in the list of branches, thus the instruction is incorrectly classified as not a branch.

(It was unclear where this could be added as a regression test, so I haven't).